### PR TITLE
docs: add frontend architecture and services contract references

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -1,0 +1,143 @@
+# Frontend architecture — the `src/` skeleton
+
+How a `@pathscale/ui` application is laid out, so a new app doesn't start from a blank
+directory and an existing one stays recognisable to anyone who has worked on another.
+
+This starter ships the **core** of the skeleton. The rest of this document describes the
+shape a full application grows into — each section marks whether the starter has that
+piece yet, so nothing here is a claim about code that isn't present.
+
+Neighbours: [`frontend-conventions.md`](frontend-conventions.md) for the working
+agreement, [`frontend-services-contract.md`](frontend-services-contract.md) for backend
+wiring, and the [`@pathscale/ui` usage
+reference](https://github.com/pathscale/ui/blob/master/docs/ui-usage.md) for components,
+theming and forms.
+
+## The skeleton
+
+**In this starter:**
+
+```
+src/
+  App.tsx  index.tsx  index.css  env.d.ts
+  assets/  components/  config/  features/  layouts/  lib/  scripts/  styles/
+```
+
+**Added as an app grows** — a data-backed app ends up with all of these:
+
+```
+  api/  constants/  hooks/  models/  services/  stores/  utils/
+```
+
+**Added when the app needs them:** `pages/`, `routes.ts`, `types/`, `schemas/`,
+`contexts/`, `test/`.
+
+Keep the names. A directory called `helpers/` or `store/` costs every future reader — and
+every agent — the moment they have to work out whether it means `utils/` or `stores/`.
+
+## What belongs where
+
+### `components/` vs `features/` — the split that matters most
+
+Both are in this starter, and getting this wrong is the most common structural mistake.
+
+- **`components/`** — reusable and domain-agnostic. Would it still make sense in a
+  different app? Then it goes here. The starter's `src/components/Logo.tsx` and
+  `Footer.tsx` are the shape: no product knowledge in them.
+- **`features/`** — one directory per product area, owning its slice end to end. The
+  starter has `src/features/auth/` and `src/features/home/`. Inside a feature the
+  convention is `components/`, `hooks/`, `pages/`, plus whatever that feature alone needs.
+
+The test: **would this make sense outside this product area?** Yes → `components/`.
+No → that feature's folder.
+
+A feature may import from `components/`. **`components/` must never import from
+`features/`** — that edge is what keeps the shared layer shared, and it is worth enforcing
+in review.
+
+### `layouts/` — page shells
+
+In this starter: `AppShell.tsx`, `AppLayout.tsx`, `AuthLayout.tsx`. Layouts are composed
+by the router and hold structural chrome — navigation, footers, auth framing. No data
+fetching, no product logic.
+
+### `config/` and the `config.ts` file
+
+`src/config/` holds configuration modules; this starter has `src/config/routes.ts`. Apps
+commonly add `featureFlags.ts` and `i18n.ts` beside it.
+
+A full app also has a **`src/config.ts` file** next to the `config/` directory, for
+environment and runtime config. The two coexist and are not duplicates — worth knowing
+before you "tidy up" one into the other.
+
+### `lib/` vs `utils/`
+
+- **`lib/`** — self-contained utilities with real internal complexity, often their own
+  subdirectory. The starter has `src/lib/theme.ts`.
+- **`utils/`** *(not in the starter yet)* — small stateless helpers, one concern per file.
+
+Rule of thumb: if it grows a subdirectory and internal state, it belongs in `lib/`.
+
+### `styles/`, `assets/`, `scripts/`
+
+- **`styles/`** — global CSS and themes (`src/styles/themes/` here). Component styling is
+  Tailwind utilities plus `@pathscale/ui` tokens.
+- **`assets/`** — static files.
+- **`scripts/`** — build and codegen scripts run through `package.json`. Never imported by
+  `src/`.
+
+### The data layer *(not in this starter)*
+
+A backend-connected app adds these. Full detail in
+[`frontend-services-contract.md`](frontend-services-contract.md):
+
+- **`api/`** — transport wiring only: adapter configuration and the exported session
+  objects. No business logic, and nothing importing from `features/`.
+- **`models/`** — generated DTOs describing backend payloads. **Never hand-edited.**
+- **`services/`** — business logic and error normalisation. Entered when there is logic to
+  own, not as a mandatory relay between hooks and `api/`.
+- **`hooks/`** — one hook per endpoint or interaction, wrapping `@tanstack/solid-query`.
+  This is what components consume; they should never call the API directly.
+- **`constants/`** — fixed values with no logic, notably centralised query keys.
+- **`stores/`** — global state as module-level `createSignal` singletons, imported
+  directly, no provider.
+- **`contexts/`** — only for values that genuinely cannot be global because they belong to
+  one subtree. Reach for a store first; a context is the exception, not the default.
+
+## Routing
+
+Up to three layers. They stack — a later one never replaces an earlier one.
+
+**1. Path constants — `src/config/routes.ts`.** Present here, and it should exist in every
+app from day one. Every path string comes from this module; never hard-code a route string
+in a component.
+
+**2. The route table — `src/routes.ts`** *(not in this starter)*. Exports
+`routes: RouteConfig[]` mapping paths to components, layouts and guards. Worth adding once
+the route list outgrows readability inline.
+
+Below that threshold — and this starter is below it — routes are declared as `<Route>`
+elements directly in `src/App.tsx`, with guards as wrapper components. That is a
+legitimate end state for a small app, not a deficiency to fix.
+
+**3. Derived groupings — `src/routing/`** *(not in this starter)*. Filters the route table
+into the groups a shell renders, and can carry access policy. This layer **imports** the
+route table; it is a consumer of layer 2, never an alternative to it.
+
+So "`routes.ts` or `routing/`?" is a false choice: an app with `routing/` has `routes.ts`
+too, and both sit on `config/routes.ts`.
+
+## Adding something new — where does it go?
+
+| you are adding | it goes in |
+|---|---|
+| a screen | that feature's `pages/`, registered in `App.tsx` or `routes.ts` |
+| a widget used by one feature | that feature's `components/` |
+| a widget used by three features | `components/` |
+| page chrome | `layouts/` |
+| a path | `config/routes.ts`, always |
+| a backend call | `hooks/` — see the services contract |
+| global state | `stores/` |
+| a value scoped to one subtree | `contexts/` |
+| a pure helper | `utils/`, or `lib/` if it needs its own directory |
+| a type describing backend data | nowhere by hand — regenerate `models/` |

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -52,11 +52,17 @@ Run the smallest relevant check first; widen only if it passes or the failure is
 
 Load only the reference needed for the current task — not all of them automatically:
 
-- **project map** — feature structure, routes, stores and app flow
-- **services contract** — endpoint wiring, hooks and generated DTO rules
-- **UI conventions** — SolidJS and `@pathscale/ui` usage
-- **validation** — exact commands for this repository (see above)
+- **[Frontend architecture](frontend-architecture.md)** — the `src/` skeleton: what
+  belongs in each directory, the `components/` vs `features/` split, where state lives,
+  and the routing layers. Marks which pieces this starter ships and which are the shape a
+  full app grows into.
+- **[Frontend services contract](frontend-services-contract.md)** — how a backend endpoint
+  is wired from its contract JSON through generated DTOs to the hook a component consumes,
+  and how errors surface. This starter has no backend wiring yet; the doc is the target
+  shape for an app that adds one.
+- **[`@pathscale/ui` usage reference](https://github.com/pathscale/ui/blob/master/docs/ui-usage.md)**
+  — theming, component conventions, forms, table, toast, icons. Lives in the `ui` repo and
+  is the single source of truth. Don't copy it here.
 
-> **TODO — these reference docs do not exist yet.** The names above are the intended
-> split; writing them is a follow-up project. Until they exist, this file plus the
-> services JSON is the reference. Don't go looking for files that aren't there.
+Validation is not a separate reference: this repository's exact commands are in the
+**Validation** section above.

--- a/docs/frontend-services-contract.md
+++ b/docs/frontend-services-contract.md
@@ -1,0 +1,129 @@
+# Frontend services contract — contract to hook
+
+How a backend endpoint reaches a component in a `@pathscale/ui` application built on the
+WebSocket RPC adapter (`@pathscale/wss-adapter`).
+
+**This starter has no backend wiring** — no `api/`, `models/`, `services/` or `hooks/`
+directory yet. This document is the target shape for an app that adds one, so the wiring
+is consistent from the first endpoint rather than reinvented per app.
+
+It documents the **pattern**, not a list of endpoints. Endpoints live in an app's own
+service contract files and are already machine-readable there; any list here would be
+stale within a week.
+
+## The rule that comes before everything
+
+**The service contract JSON is authoritative.** Endpoints, parameters, returns, error
+variants and roles all come from it. If something is not in the contract, it does not
+exist as far as the frontend is concerned.
+
+Do not invent an endpoint, add a parameter the contract doesn't declare, or assume a
+return shape because it would be convenient. When something you need is missing, **say so
+and stop** — that is a backend conversation, not a frontend workaround. Guessing produces
+code that typechecks, passes review, and fails against a real server.
+
+An app carries one contract file per backend service, conventionally under `docs/` as
+`<service>.services.json`. Each contract maps to its own subtree under `src/models/`.
+
+## The chain
+
+```
+docs/<service>.services.json        the contract — authoritative, hand-maintained
+  │
+  ├─(codegen)─> src/models/<contract>/…        generated DTOs, enums, error catalog
+  └─(codegen)─> src/api/services/<contract>/…  generated method maps (JSON)
+
+src/api/configure.ts    reads the contract, configures @pathscale/wss-adapter
+  └─> src/api/index.ts        exports callable session objects
+        └─> src/hooks/<group>/useX.ts    solid-query wrapper — what components consume
+              └─> src/services/…         only where there is domain logic to own
+```
+
+Two things about this are easy to get wrong:
+
+**`src/api/services/` is generated, and the adapter configuration does not read it.** The
+method map handed to the adapter is built in-process from the contract JSON. The files
+under `src/api/services/` are a *separate emission* of the same information, imported by
+hand in only a couple of narrow places. Don't treat that directory as the wiring, and
+don't hand-edit it.
+
+**`src/services/` is not a mandatory hop.** A plain read goes hook → `api/`. The
+`services/` layer is entered when there is real work to own — multi-step flows, error
+normalisation, connection lifecycle. Routing every call through it "for consistency" adds
+a pass-through file that does nothing.
+
+## What is generated, and what you write
+
+The codegen script (conventionally `src/scripts/schema.js`, run via `bun run schema`)
+reads each contract and emits:
+
+| generated | contents |
+|---|---|
+| `src/models/<contract>/<service>/<Endpoint>Dto.ts` | request params + response types |
+| `src/models/<contract>/<service>/index.ts` | barrel re-export |
+| `src/models/<contract>/enums/` | contract enums, one file each, plus an index |
+| `src/models/<contract>/errorCatalog.ts` | typed error variants, where the contract declares them |
+| `src/api/services/<contract>/<service>.json` | endpoint code → name + parameter names |
+
+**All of it is overwritten on the next run.** Edits are silently lost. Generated files
+carry a "DO NOT MODIFY IT BY HAND" banner — if a file in `models/` has no banner, it is
+hand-written and safe to edit, which is worth checking rather than assuming either way.
+
+Hand-written: everything in `hooks/` and `services/`, the query keys in `constants/`, and
+`api/configure.ts`.
+
+## The hook layer
+
+One hook per endpoint, wrapping `@tanstack/solid-query`. Four conventions, all
+load-bearing:
+
+- **Types come from `models/`** — never hand-declared next to the hook. A hand-written
+  interface that mirrors a DTO will drift the first time the contract moves, and nothing
+  will catch it.
+- **Query keys come from a central module** (`src/constants/queryKeys.ts`), never inlined.
+  Invalidation depends on keys being constructed the same way in every call site.
+- **Gate `enabled` on connection readiness.** With a WebSocket transport the socket is not
+  up on first paint; a query that doesn't gate will fire and fail before the session
+  exists.
+- **Unwrap the response defensively.** The adapter may return the payload directly or
+  nested under `params` — handle both.
+
+Components call the hook and read its reactive state. They never touch the session objects
+from `api/` directly.
+
+## Adding an endpoint
+
+1. **Confirm it exists in the contract.** If not, stop — nothing below is valid.
+2. **Regenerate.** Never hand-write the DTO.
+3. **Commit the generated output** with your change; it is checked in.
+4. **Add a query key** to the central module.
+5. **Write the hook**, mirroring the nearest existing one — same unwrapping, same gate.
+6. **Add a `services/` function only if there is logic to own.** Otherwise skip it.
+7. **Consume the hook** from the component.
+
+## How errors surface
+
+Where a contract declares error variants, codegen emits a typed error catalog, and a
+normalisation module in `services/` turns raw adapter errors into something a component
+can act on. Four rules that module should encode:
+
+- **Never branch on a message string.** Control flow keys off the error `kind` and numeric
+  `code`. Messages are display text; they get rewritten, translated, and will break any
+  logic built on them.
+- **Allowlist what reaches the UI.** Pass through the safe structured fields — retry
+  timings, attempt counts — and drop everything else, so a backend that later attaches a
+  token to an error payload cannot leak it into a component.
+- **Never surface the raw error.** Keep it for logging; don't render it.
+- **Distinguish known from unknown.** A declared contract variant and an unrecognised
+  failure should not take the same path — unknown failures get a generic message rather
+  than an unhandled branch.
+
+Transport-level failures are handled **once, centrally**, in the adapter's `onError`:
+auth failures invalidate the session, everything else is logged. Individual hooks do not
+re-implement that.
+
+## When the contract and the code disagree
+
+The contract wins. If `models/` looks wrong, regenerate before you debug — the usual cause
+is a contract that moved and generated files that didn't. If the contract itself looks
+wrong, that is a backend conversation. Don't paper over it in a hook.


### PR DESCRIPTION
Gives a new app built from this starter the two things it would otherwise have to rederive: **where code goes**, and **how a backend endpoint is wired**.

## Why here

These were briefly published in `pathscale/ui` and removed again (pathscale/ui#200) — that version described private application repositories in a public repo. This starter is the right home: it's public, and it's already the thing new apps begin from.

Rewritten from scratch against **this** repository. No private repository is named, and no path from one is cited.

## The two docs

**`frontend-architecture.md`** — the `src/` skeleton. The `components/` vs `features/` split (with the one-way import rule), layouts, `lib/` vs `utils/`, `stores/` vs `contexts/`, the three routing layers, and a "where does this go?" table.

**`frontend-services-contract.md`** — the contract-to-hook chain: what codegen owns versus what you write, the four hook conventions, and four rules for error normalisation (chief among them: never branch on a message string).

## Honest about what's here

This starter ships part of the skeleton and none of the data layer. Rather than describe directories that don't exist, both docs mark each section as either **in this starter** or **the shape a full app grows into**. The services doc says outright that there is no `api/`, `models/`, `services/` or `hooks/` here yet and that it describes a target.

That also makes the gap visible: if you'd like the starter to *ship* that scaffolding rather than just document it, that's a natural follow-up and I'd suggest it.

## Also

Replaces the References TODO block in `frontend-conventions.md`, which listed four references that didn't exist. Three now do. `validation` is dropped as a separate entry — the **Validation** section directly above it already has this repo's exact commands, so a reference entry would only drift from it.

## Verification

Every `src/` path cited was checked against this repository. Scanned both new files for private repository names: zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)