### PR TITLE
feat: add the remaining skeleton directories with READMEs

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -3,9 +3,10 @@
 How a `@pathscale/ui` application is laid out, so a new app doesn't start from a blank
 directory and an existing one stays recognisable to anyone who has worked on another.
 
-This starter ships the **core** of the skeleton. The rest of this document describes the
-shape a full application grows into — each section marks whether the starter has that
-piece yet, so nothing here is a claim about code that isn't present.
+This starter ships the working core, plus the rest of the skeleton as **empty directories
+with a README each** — so the shape is there from the first commit and you are never
+guessing where something goes. Each section below marks whether the directory has code in
+it yet, so nothing here is a claim about code that isn't present.
 
 Neighbours: [`frontend-conventions.md`](frontend-conventions.md) for the working
 agreement, [`frontend-services-contract.md`](frontend-services-contract.md) for backend
@@ -15,7 +16,7 @@ theming and forms.
 
 ## The skeleton
 
-**In this starter:**
+**With code in this starter:**
 
 ```
 src/
@@ -23,14 +24,15 @@ src/
   assets/  components/  config/  features/  layouts/  lib/  scripts/  styles/
 ```
 
-**Added as an app grows** — a data-backed app ends up with all of these:
+**Present as empty directories, each with a README describing what belongs there** — a
+data-backed app fills all of them:
 
 ```
   api/  constants/  hooks/  models/  services/  stores/  utils/
 ```
 
-**Added when the app needs them:** `pages/`, `routes.ts`, `types/`, `schemas/`,
-`contexts/`, `test/`.
+**Not here at all; add when the app needs them:** `pages/`, `routes.ts`, `types/`,
+`schemas/`, `contexts/`, `test/`.
 
 Keep the names. A directory called `helpers/` or `store/` costs every future reader — and
 every agent — the moment they have to work out whether it means `utils/` or `stores/`.
@@ -74,7 +76,7 @@ before you "tidy up" one into the other.
 
 - **`lib/`** — self-contained utilities with real internal complexity, often their own
   subdirectory. The starter has `src/lib/theme.ts`.
-- **`utils/`** *(not in the starter yet)* — small stateless helpers, one concern per file.
+- **`utils/`** *(empty here)* — small stateless helpers, one concern per file.
 
 Rule of thumb: if it grows a subdirectory and internal state, it belongs in `lib/`.
 
@@ -86,10 +88,10 @@ Rule of thumb: if it grows a subdirectory and internal state, it belongs in `lib
 - **`scripts/`** — build and codegen scripts run through `package.json`. Never imported by
   `src/`.
 
-### The data layer *(not in this starter)*
+### The data layer *(directories present, empty)*
 
-A backend-connected app adds these. Full detail in
-[`frontend-services-contract.md`](frontend-services-contract.md):
+A backend-connected app fills these; each has a README repeating the rule in place. Full
+detail in [`frontend-services-contract.md`](frontend-services-contract.md):
 
 - **`api/`** — transport wiring only: adapter configuration and the exported session
   objects. No business logic, and nothing importing from `features/`.

--- a/docs/frontend-services-contract.md
+++ b/docs/frontend-services-contract.md
@@ -3,9 +3,11 @@
 How a backend endpoint reaches a component in a `@pathscale/ui` application built on the
 WebSocket RPC adapter (`@pathscale/wss-adapter`).
 
-**This starter has no backend wiring** — no `api/`, `models/`, `services/` or `hooks/`
-directory yet. This document is the target shape for an app that adds one, so the wiring
-is consistent from the first endpoint rather than reinvented per app.
+**This starter has the directories but no backend wiring** — `api/`, `models/`,
+`services/`, `hooks/`, `stores/`, `constants/` and `utils/` are present, each with a
+README describing what belongs there, and otherwise empty. This document is the shape to
+fill them in, so the wiring is consistent from the first endpoint rather than reinvented
+per app.
 
 It documents the **pattern**, not a list of endpoints. Endpoints live in an app's own
 service contract files and are already machine-readable there; any list here would be

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,16 @@
+# `api/` — transport wiring
+
+Adapter configuration and the exported session objects hooks call. Nothing else.
+
+**Belongs here:** `configure.ts` (remote URLs, method map, `timeout`, `onError`,
+`onDisconnect`, then `wssAdapter.configure()`) and `index.ts` (exports the callable
+sessions).
+
+**Does not belong:** business logic, domain-aware retries, anything importing from
+`features/`.
+
+**Generated:** `api/services/` — one JSON method map per service, emitted by codegen.
+Never hand-edited. Note the adapter config does *not* read it; it builds its method map
+from the contract JSON directly.
+
+See [`docs/frontend-services-contract.md`](../../docs/frontend-services-contract.md).

--- a/src/constants/README.md
+++ b/src/constants/README.md
@@ -1,0 +1,7 @@
+# `constants/` — fixed values, no logic
+
+Notably `queryKeys.ts`: every query key in one module, never inlined at the call site.
+Invalidation only works if keys are built the same way everywhere.
+
+**Does not belong:** anything computed, anything reading configuration. Those are `config/`
+or `utils/`.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -1,0 +1,13 @@
+# `hooks/` — what components consume
+
+One hook per endpoint or interaction, wrapping `@tanstack/solid-query` and returning
+reactive state. Components call these; they never touch `api/` directly.
+
+Four conventions, all load-bearing:
+
+- Types come from `models/` — never hand-declared beside the hook.
+- Query keys come from `constants/` — never inlined.
+- Gate `enabled` on connection readiness; the socket is not up on first paint.
+- Unwrap the response defensively — the payload may arrive nested under `params`.
+
+Group subdirectories by domain or by service. Either is fine; match what's already here.

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,0 +1,12 @@
+# `models/` — generated DTOs
+
+Every type describing a backend payload, generated from the service contract.
+
+**Never hand-edit anything in a generated subdirectory.** Edits are silently lost on the
+next codegen run. Generated files carry a "DO NOT MODIFY IT BY HAND" banner — if a file
+here has no banner it is hand-written, which is worth checking rather than assuming.
+
+**Does not belong:** view models, form shapes, anything not describing the wire. Those are
+hand-written types and live with the code that uses them.
+
+See [`docs/frontend-services-contract.md`](../../docs/frontend-services-contract.md).

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,13 @@
+# `services/` — business logic and error normalisation
+
+Where an API call becomes a domain operation: sequencing several calls, normalising errors
+into something a component can act on, owning connection lifecycle.
+
+**Not a mandatory hop.** A plain read goes hook → `api/`. Enter this layer when there is
+logic to own; routing every call through it "for consistency" just adds a pass-through
+file.
+
+**Belongs here:** connection/session lifecycle (the readiness gate hooks check), auth
+flows, error normalisation.
+
+**Does not belong:** JSX, component imports, route knowledge.

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -1,0 +1,9 @@
+# `stores/` — global state
+
+Module-level `createSignal` singletons, imported directly. No provider, no context.
+
+This is the default for shared state and covers nearly everything — auth, connection
+status, locale.
+
+Use a **context** instead only when a value genuinely cannot be global because it belongs
+to one subtree. That is the exception; reach for a store first.

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,0 +1,9 @@
+# `utils/` — small stateless helpers
+
+One concern per file: formatting, parsing, coercion.
+
+If it grows a subdirectory and internal state, it belongs in `lib/` instead. That is the
+whole distinction.
+
+**Does not belong:** anything importing from `features/`, and anything that talks to the
+network.


### PR DESCRIPTION
This was meant to be part of #6 but missed the merge — #6 landed before I pushed the commit, so master has the reference docs without the directories they describe. Cherry-picked onto current master.

## What it adds

`api/`, `constants/`, `hooks/`, `models/`, `services/`, `stores/` and `utils/` — each with a README stating what belongs there and what does not. The never-hand-edit rule sits in `models/`, the four hook conventions in `hooks/`, the store-before-context rule in `stores/`.

No working code. This is the shape, not an implementation.

## Why it matters for the docs

Without it, `frontend-architecture.md` has to hedge every data-layer sentence — *"not in this starter"* — and a new app still opens a blank `src/` and guesses. With the directories present, the docs describe what is actually there. This PR updates both files accordingly.

Two hedges remain and are correct: `src/routes.ts` and `src/routing/` genuinely aren't here, because this starter declares routes inline in `App.tsx` — a legitimate end state at this size, which the doc says explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)